### PR TITLE
bump maven-shade-plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>2.0</version>
+        <version>2.1</version>
         <executions>
           <execution>
             <phase>package</phase>


### PR DESCRIPTION
The project previously did not build with 'mvn package' due to problems documented here:
https://cwiki.apache.org/confluence/display/MAVEN/AetherClassNotFound
